### PR TITLE
chore(ci): enable workflow Helm test on PRs

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -17,9 +17,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # #############################################################################
 ---
-name: Helm Test (dispatch)
+name: Helm Test
 
 on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+    branches:
+      - '*'
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I'd love if the Helm test workflow is running on PRs.

This would help to verify if a PR breaks the Helm chart.
Currently it is only triggered via manual `workflow_dispatch`.
Other projects in eclipse-tractusx test it the same way.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))